### PR TITLE
Experimental llvm-cov integration

### DIFF
--- a/integration-tests/flake-utils/cpp/package.nix
+++ b/integration-tests/flake-utils/cpp/package.nix
@@ -1,9 +1,9 @@
 # python packages context
 {
-  stdenv,
+  clangStdenv,
   pkgs,
 }:
-stdenv.mkDerivation {
+clangStdenv.mkDerivation {
   name = "cpp-package";
   src = ./.;
 

--- a/integration-tests/flake-utils/cpp/project.nix
+++ b/integration-tests/flake-utils/cpp/project.nix
@@ -8,5 +8,13 @@
   languages.cpp = {
     enable = true;
     callPackageFunction = import ./package.nix;
+    coverage.enable = true;
+  };
+  tools.experimental.llvm-cov = {
+    enable = true;
+    coverageTargets = [
+      "build/tests/dummy_test"
+      "build/src/greet"
+    ];
   };
 }

--- a/integration-tests/flake-utils/cpp/project.nix
+++ b/integration-tests/flake-utils/cpp/project.nix
@@ -13,6 +13,7 @@
   tools.experimental.llvm-cov = {
     enable = true;
     coverageTargets = [
+      # Relative paths to build executables / libraries to generate coverage reports for
       "build/tests/dummy_test"
       "build/src/greet"
     ];

--- a/modules/projects/languages/cpp/hooks/coverage.sh
+++ b/modules/projects/languages/cpp/hooks/coverage.sh
@@ -1,0 +1,2 @@
+# shellcheck shell=bash
+export NIX_CFLAGS_COMPILE+=" -fprofile-instr-generate -fcoverage-mapping"

--- a/modules/projects/tools/default.nix
+++ b/modules/projects/tools/default.nix
@@ -24,6 +24,7 @@
     ./jetbrains
     ./keep-sorted.nix
     ./lefthook.nix
+    ./llvm-cov.nix
     ./mdformat.nix
     ./minimal-flake.nix
     ./mypy.nix

--- a/modules/projects/tools/llvm-cov.nix
+++ b/modules/projects/tools/llvm-cov.nix
@@ -1,6 +1,7 @@
 # rising-tide flake context
 {
   lib,
+  risingTideLib,
   ...
 }:
 # project context
@@ -21,9 +22,15 @@ in
       enable = lib.mkEnableOption "Enable llvm-cov integration";
       package = lib.mkPackageOption pkgs [ "llvmPackages" "libllvm" ] { };
       coverageTargets = lib.mkOption {
-        type = lib.types.listOf lib.types.str;
-        description = "The targets to generate coverage data for";
+        type = lib.types.listOf risingTideLib.types.subpath;
+        description = "Relative paths to libraries / executables to generate coverage reports for";
         default = [ ];
+        # FIXME: Is this the most convenient thing? Also: requiring the build/ prefix feels redundant,
+        # however it's useful for discoverability.
+        example = [
+          "build/tests/dummy_test"
+          "build/src/greet"
+        ];
       };
     };
   };

--- a/modules/projects/tools/llvm-cov.nix
+++ b/modules/projects/tools/llvm-cov.nix
@@ -1,0 +1,88 @@
+# rising-tide flake context
+{
+  lib,
+  ...
+}:
+# project context
+{
+  config,
+  pkgs,
+  ...
+}:
+let
+  getCfg = projectConfig: projectConfig.tools.experimental.llvm-cov;
+  cfg = getCfg config;
+  llvm-profdataExe = lib.getExe' cfg.package "llvm-profdata";
+  llvm-covExe = lib.getExe' cfg.package "llvm-cov";
+in
+{
+  options = {
+    tools.experimental.llvm-cov = {
+      enable = lib.mkEnableOption "Enable llvm-cov integration";
+      package = lib.mkPackageOption pkgs [ "llvmPackages" "libllvm" ] { };
+      coverageTargets = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        description = "The targets to generate coverage data for";
+        default = [ ];
+      };
+    };
+  };
+
+  config = lib.mkMerge [
+    (lib.mkIf cfg.enable {
+      tasks.test.serialTasks = lib.mkAfter [ "test:llvm-cov-report" ];
+      tools = {
+        go-task = {
+          enable = true;
+          taskfile = {
+            tasks = lib.mkMerge (
+              [
+                {
+                  "llvm-cov:combine" = {
+                    desc = "Combine coverage data";
+                    cmds = [
+                      "${llvm-profdataExe} merge -sparse -o build/default.profdata $(find build -name '*.profraw')"
+                    ];
+                  };
+                  "llvm-cov:report" = {
+                    desc = "Report on coverage data";
+                    cmds = [
+                      "${llvm-covExe} show -instr-profile=build/default.profdata -format=html -output-dir=build/coverage-"
+                    ];
+                  };
+                  "test:llvm-cov-report" = {
+                    desc = "Generate a coverage report";
+                  };
+                }
+              ]
+              ++ (builtins.map (target: {
+                "llvm-cov:report:${target}" = {
+                  desc = "Report on coverage data for ${target}";
+                  deps = [ "llvm-cov:combine" ];
+                  cmds = [
+                    ''
+                      ${llvm-covExe} show ${target} -instr-profile=build/default.profdata -format=html \
+                        -show-line-counts-or-regions \
+                        -use-color \
+                        -show-instantiation-summary \
+                        -show-branches=count \
+                        -output-dir=$(dirname ${target})/coverage-report
+                      echo "Coverage report generated at $(dirname ${target})/coverage-report/index.html"
+                    ''
+                    ''
+                      ${llvm-covExe} report ${target} -instr-profile=build/default.profdata \
+                        -show-region-summary=false \
+                        -show-branch-summary=false \
+                        -show-branch-summary=false
+                    ''
+                  ];
+                };
+                "test:llvm-cov-report".deps = [ "llvm-cov:report:${target}" ];
+              }) cfg.coverageTargets)
+            );
+          };
+        };
+      };
+    })
+  ];
+}


### PR DESCRIPTION
As written, this only works if `clang` is used as the compiler instead of gcc, as it uses `llvm-cov` in place of `lcov` / `gcov`.

The `flake-utils/cpp` integration test has this currently enabled. It can be tested by:

1. Clone rising tide
2. `cd integration-tests/flake-utils/cpp`
3. `nix develop`
4. Inside the nix develop shell run: `task cmake:build test`. This will run the CMake build and then run tests and then generate HTML reports for coverage data under `build/src/coverage-report` and `build/tests/coverage-report` and print a brief summary to the console.