### PR TITLE
Reduce the number of packages required for dev shells

### DIFF
--- a/modules/projects/tools/shellHooks/mk-shell-hook.sh
+++ b/modules/projects/tools/shellHooks/mk-shell-hook.sh
@@ -54,8 +54,10 @@ function configShellHook() {
   uniqueArray postShellHooks
   runHook postShellHook
   echo "Finished executing configShellHook"
+
+  # Redefine function to avoid re-execution
+  # shellcheck disable=SC2317
+  function configShellHook() { :; }
 }
 
 preShellHooks+=(@bashSafeName@PreShell)
-# shellcheck disable=SC2034
-shellHook+=" configShellHook"


### PR DESCRIPTION
Do this by inlining the shell hook created by tools.shellHooks