### PR TITLE
fix: Ensure non-formatting linters run before formatting linters

### DIFF
--- a/modules/projects/tools/clang-tidy.nix
+++ b/modules/projects/tools/clang-tidy.nix
@@ -59,6 +59,8 @@ in
               "*.hh"
               "*.hpp"
             ];
+            # Ensure linters that don't format run first
+            priority = -10;
           };
         };
       };

--- a/modules/projects/tools/clangd-tidy.nix
+++ b/modules/projects/tools/clangd-tidy.nix
@@ -52,6 +52,8 @@ in
               "*.hh"
               "*.hpp"
             ];
+            # Ensure linters that don't format run first
+            priority = -10;
           };
         };
       };

--- a/modules/projects/tools/deadnix.nix
+++ b/modules/projects/tools/deadnix.nix
@@ -34,6 +34,8 @@ in
             includes = [
               "*.nix"
             ];
+            # Ensure linters that don't format run first
+            priority = -10;
           };
         };
       };

--- a/modules/projects/tools/keep-sorted.nix
+++ b/modules/projects/tools/keep-sorted.nix
@@ -26,6 +26,8 @@ in
           formatter.keep-sorted = {
             command = keepSortedExe;
             includes = [ "*" ];
+            # Ensure linters that don't format run first
+            priority = -10;
           };
         };
       };

--- a/modules/projects/tools/ruff.nix
+++ b/modules/projects/tools/ruff.nix
@@ -59,6 +59,8 @@ in
                 "*.py"
                 "*.pyi"
               ];
+              # Ensure linters that don't format run first
+              priority = -10;
             };
             formatter.ruff-format = lib.mkIf cfg.format.enable {
               command = ruffExe;

--- a/modules/projects/tools/shellcheck.nix
+++ b/modules/projects/tools/shellcheck.nix
@@ -48,6 +48,8 @@ in
               "*.bash"
               "*.bats"
             ];
+            # Ensure linters that don't format run first
+            priority = -10;
           };
         };
       };

--- a/modules/projects/tools/statix.nix
+++ b/modules/projects/tools/statix.nix
@@ -50,6 +50,8 @@ in
             includes = [
               "*.nix"
             ];
+            # Ensure linters that don't format run first
+            priority = -10;
           };
         };
       };


### PR DESCRIPTION
If we ran formatting linters first, they might want to reformat the code again
after non-formatting linters (e.g. dead code detectors) run.
