### PR TITLE
protobuf: Generate CMake config files for C++ protobuf libraries

### DIFF
--- a/integration-tests/flake-utils/cpp/project.nix
+++ b/integration-tests/flake-utils/cpp/project.nix
@@ -1,3 +1,4 @@
+{ lib, ... }:
 {
   name = "cpp-package";
   namespacePath = [
@@ -9,6 +10,7 @@
     enable = true;
     callPackageFunction = import ./package.nix;
     coverage.enable = true;
+    sanitizers.tsan.enable = lib.mkForce true;
   };
   tools.experimental.llvm-cov = {
     enable = true;

--- a/integration-tests/flake-utils/protobuf/example-extended/project.nix
+++ b/integration-tests/flake-utils/protobuf/example-extended/project.nix
@@ -13,8 +13,9 @@
     cpp.extraDependencies = pkgs: [
       {
         package = pkgs.example-cpp;
-        protobufLibraryNames = [ "example-cpp-proto" ];
-        grpcLibraryNames = [ "example-cpp-grpc" ];
+        packageName = "example-cpp";
+        protobufLibraryNames = [ "example-cpp::proto" ];
+        grpcLibraryNames = [ "example-cpp::grpc" ];
       }
     ];
     python.extraDependencies = pythonPackages: [ pythonPackages.example-py ];

--- a/integration-tests/flake-utils/protobuf/example-grandchild/project.nix
+++ b/integration-tests/flake-utils/protobuf/example-grandchild/project.nix
@@ -13,7 +13,8 @@
     cpp.extraDependencies = pkgs: [
       {
         package = pkgs.example-extended-cpp;
-        protobufLibraryNames = [ "example-extended-cpp-proto" ];
+        packageName = "example-extended-cpp";
+        protobufLibraryNames = [ "example-extended-cpp::proto" ];
       }
     ];
     python.extraDependencies = pythonPackages: [ pythonPackages.example-extended-py-with-custom-name ];

--- a/modules/projects/conventions/rising-tide/cpp.nix
+++ b/modules/projects/conventions/rising-tide/cpp.nix
@@ -37,7 +37,8 @@ in
             "leak:python3"
             # keep-sorted end
           ];
-          tsan.enable = true;
+          # TSAN integration isn't currently correct as all dependencies should be built with TSAN
+          tsan.enable = false;
         };
         tools = {
           # keep-sorted start block=yes


### PR DESCRIPTION
This now enables generated C++ protobuf packages to be located with `find_package(protobuf-package-name)` and then referenced as `protobuf-package-name::proto` or `protobuf-package-name::grpc` or `protobuf-package-name::default` which equivalent to `protobuf-package-name::grpc` when it exists or otherwise `protobuf-package-name::proto`.