### PR TITLE
minor: fail shell entry when already in a shell

### DIFF
--- a/modules/projects/mkShell/mk-shell-hook.sh
+++ b/modules/projects/mkShell/mk-shell-hook.sh
@@ -33,6 +33,11 @@ function configShellHook() {
     export FLAKE_ROOT
   fi
 
+  if [ -n "$IN_NIX_SHELL" ]; then
+    echo "Error: You are already in a Nix shell."
+    exit 1
+  fi
+
   uniqueArray preShellHooks
   runHook preShellHook
 

--- a/modules/projects/mkShell/mk-shell-hook.sh
+++ b/modules/projects/mkShell/mk-shell-hook.sh
@@ -33,10 +33,14 @@ function configShellHook() {
     export FLAKE_ROOT
   fi
 
-  if [ -n "$IN_NIX_SHELL" ]; then
+  if [ -n "$IN_RISING_TIDE_SHELL" ]; then
     echo "Error: You are already in a Nix shell."
     exit 1
   fi
+  # Configure env variable to prevent double entering shells. 
+  # We cannot use IN_NIX_SHELL because that variable gets set before
+  # any shell hooks and it fails on initial shell entry. 
+  export IN_RISING_TIDE_SHELL=1
 
   uniqueArray preShellHooks
   runHook preShellHook

--- a/modules/projects/mkShell/mk-shell-hook.sh
+++ b/modules/projects/mkShell/mk-shell-hook.sh
@@ -37,9 +37,9 @@ function configShellHook() {
     echo "Error: You are already in a Nix shell."
     exit 1
   fi
-  # Configure env variable to prevent double entering shells. 
+  # Configure env variable to prevent double entering shells.
   # We cannot use IN_NIX_SHELL because that variable gets set before
-  # any shell hooks and it fails on initial shell entry. 
+  # any shell hooks and it fails on initial shell entry.
   export IN_RISING_TIDE_SHELL=1
 
   uniqueArray preShellHooks


### PR DESCRIPTION
Nixago misbehaves (fails to update/generate taskfiles, potentially other issues) when entering a nested devshell. This PR exits early if this is attempted. 